### PR TITLE
People page can now be opened by grave number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "ag-hochstrasse-web-application",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ag-hochstrasse-web-application",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@primer/css": "^21.3.6",
-        "@primer/octicons-react": "^1.11.0",
+        "@primer/octicons-react": "^19.11.0",
         "@primer/react": "^36.27.0",
         "@supabase/auth-ui-react": "^0.4.7",
         "@supabase/auth-ui-shared": "^0.1.8",
@@ -25,7 +25,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.1",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ag-hochstrasse-web-application",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "dependencies": {
     "@primer/css": "^21.3.6",
@@ -20,7 +20,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.1",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,6 +88,8 @@ export function App() {
             <Route path="/people" element={<PeopleTable all />} />
             <Route path="/people/:id" element={<PersonDetail session={session} />} />
             <Route path="/people/:id/:tab" element={<PersonDetail session={session} />} />
+            <Route path="/people/grave/:id" element={<PersonDetail session={session} />} />
+            <Route path="/people/grave/:id/:tab" element={<PersonDetail session={session} />} />
 
             <Route path="/people/:id/edit" element={<EditPeople session={session} />} />
             <Route path="/people/new" element={<EditPeople session={session} insert />} />

--- a/src/assets/whatsnew.json
+++ b/src/assets/whatsnew.json
@@ -1,5 +1,10 @@
 [
     {
+        "description": "People page can now be opened by grave number (/people/grave/:number)",
+        "version": "1.0.1",
+        "thread": 87
+    },
+    {
         "description": "Conflicts can now be closed",
         "version": "1.0.0",
         "thread": 52

--- a/src/components/PersonDetail.tsx
+++ b/src/components/PersonDetail.tsx
@@ -117,9 +117,6 @@ export default function PersonDetail({ session }: any) {
 
     const fetchConflicts = async (id: string) => {
       try {
-        if (person == undefined || person == null) {
-          alert("Null")
-        }
         const { data, error } = await supabase
           .from('conflicts')
           .select('*')

--- a/src/components/PersonDetail.tsx
+++ b/src/components/PersonDetail.tsx
@@ -98,7 +98,9 @@ export default function PersonDetail({ session }: any) {
 
         setPerson(data[0]);
 
-        await fetchConflicts(data[0].id);
+        if (data[0]) {
+          await fetchConflicts(data[0].id);
+        }
       } catch (error) {
         if (error instanceof Error) {
           setError(error.message);

--- a/src/components/PersonDetail.tsx
+++ b/src/components/PersonDetail.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { Navigate, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { supabase } from '../services/supabaseClient';
 import { useState, useEffect, useRef } from 'react';
 
@@ -48,6 +48,8 @@ export default function PersonDetail({ session }: any) {
 
   const navigate = useNavigate();
 
+  const location = useLocation();
+
   //fetch user
   useEffect(() => {
     let ignore = false
@@ -80,16 +82,23 @@ export default function PersonDetail({ session }: any) {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const { data, error } = await supabase
+        const { data, error } = location.pathname.includes("grave") ? await supabase
           .from('people')
           .select('*')
-          .eq('id', id);
+          .eq('grave_number', id)
+          : await supabase
+            .from('people')
+            .select('*')
+            .eq('id', id)
+
 
         if (error) {
           throw error;
         }
 
         setPerson(data[0]);
+
+        await fetchConflicts(data[0].id);
       } catch (error) {
         if (error instanceof Error) {
           setError(error.message);
@@ -104,10 +113,11 @@ export default function PersonDetail({ session }: any) {
     fetchData();
   }, [retrigger]);
 
-  // fetch conflicts
-  useEffect(() => {
-    const fetchData = async () => {
+    const fetchConflicts = async (id: string) => {
       try {
+        if (person == undefined || person == null) {
+          alert("Null")
+        }
         const { data, error } = await supabase
           .from('conflicts')
           .select('*')
@@ -128,9 +138,6 @@ export default function PersonDetail({ session }: any) {
         setLoading(false);
       }
     };
-
-    fetchData();
-  }, []);
 
   const renderSwitch: React.FC = () => {
     switch(selectedTab) {


### PR DESCRIPTION
The people page can now be opened by grave number using the `/people/grave/:number` endpoint.

Examples:
- [Grave 1r](https://deploy-preview-88--ag-hochstrasse.netlify.app/people/grave/1r)
- [Grave 180li](https://deploy-preview-88--ag-hochstrasse.netlify.app/people/grave/180li)
- [Not existing grave](https://deploy-preview-88--ag-hochstrasse.netlify.app/people/grave/1337r)

> [!WARNING]
> Duplicate grave numbers aren't handled, just the first matching person is taken.

@ALBUS12345 could you have a look at this and do a review?